### PR TITLE
Update etag.go

### DIFF
--- a/etag.go
+++ b/etag.go
@@ -2,7 +2,7 @@ package etag
 
 import "crypto/md5"
 import "fmt"
-import "github.com/codegangsta/martini"
+import "github.com/go-martini/martini"
 import "io"
 import "net/http"
 


### PR DESCRIPTION
Changed the import to the current import of martini. Are you still using this? It might be an idea to contribute it to https://github.com/martini-contrib.
